### PR TITLE
Debug in1d because numpy >= 2.0 and conf.py to build all examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ sphinx_gallery_conf = {
     #                                    '../examples/example_02_respiration.py',
     #                                    ]),
     'within_subsection_order': FileNameSortKey,
-    'filename_pattern' : '/example_',
+    'filename_pattern' : 'example_',
 
     'ignore_pattern': '/generate_',
     'download_all_examples': False,

--- a/physio/cyclic_deformation.py
+++ b/physio/cyclic_deformation.py
@@ -204,7 +204,7 @@ def time_to_cycle(times, cycle_times,  segment_ratios = 0.4):
     # put nan when some times are in missing cycles
     if num_seg_phase == 2:
         ind_missing, = np.nonzero(np.isnan(cycle_times[:, 1]))
-        in_missing = np.in1d(np.floor(cycles), ind_missing.astype(cycles.dtype))
+        in_missing = np.isin(np.floor(cycles), ind_missing.astype(cycles.dtype))
         cycles[in_missing] = np.nan
     
     

--- a/tests/test_cyclic_deformation.py
+++ b/tests/test_cyclic_deformation.py
@@ -1,12 +1,13 @@
 import numpy as np
 from pathlib import Path
 
-from physio import compute_respiration, deform_traces_to_cycle_template
+from physio import compute_respiration, deform_traces_to_cycle_template, compute_ecg, time_to_cycle
 
 
 # read signals
 example_folder = Path(__file__).parents[1] / 'examples'
 raw_resp = np.load(example_folder / 'resp1_airflow.npy')
+raw_ecg = np.load(example_folder / 'ecg1.npy')
 srate = 1000.
 
 
@@ -42,5 +43,15 @@ def test_deform_traces_to_cycle_template():
     assert deformed_resp.shape == cycle_points.shape
 
 
+
+def test_time_to_cycle():
+    _, resp_cycles = compute_respiration(raw_resp, srate, parameter_preset='human_airflow')
+    _ , ecg_peaks = compute_ecg(raw_ecg, srate, parameter_preset = 'human_ecg')
+    inspi_ratio = resp_cycles['cycle_ratio'].median()
+    cycle_times = resp_cycles[['inspi_time', 'expi_time', 'next_inspi_time']].values
+    rpeak_phase = time_to_cycle(ecg_peaks['peak_time'].values, cycle_times, segment_ratios=[inspi_ratio])
+
+
 if __name__ == '__main__':
-    test_deform_traces_to_cycle_template()
+    # test_deform_traces_to_cycle_template()
+    test_time_to_cycle()


### PR DESCRIPTION
Currently, installing physio automatically install numpy 2.4.3 (meaning >= 2.0) with numpy.in1d removed and instead numpy.isin should be used. This PR fix it, with some other bugs of building doc due to conf.py problems